### PR TITLE
fix controller dispose error

### DIFF
--- a/lib/sync_scroller_controller.dart
+++ b/lib/sync_scroller_controller.dart
@@ -92,8 +92,8 @@ class SyncScrollController {
   void dispose() {
     _allControllers.forEach((key, value) {
       value.dispose();
-      _allControllers.remove(key);
     });
+    _allControllers.clear();
   }
 }
 


### PR DESCRIPTION
`SyncScrollController`中在`dispose`释放`value`对象时，`forEach`方法中同时修改了自身，会导致报错无法执行到父`widget`的`dispose`方法。希望在遍历结束后清除。